### PR TITLE
Rocky Linux & Server Installer scripts added

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -25,6 +25,15 @@ jobs:
     - name: Test Fedora Gaming Install
       run: sh test/fedora/test.sh installers/fedoragaming_install_packages.sh
 
+  rockyserver:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Rocky Server Install
+      run: sh test/rocky/test.sh installers/server_install_packages.sh
+
   manjarogaming:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-setups.yml
+++ b/.github/workflows/test-setups.yml
@@ -1,0 +1,18 @@
+name: Test Setups
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  rocky:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Rocky Setup
+      run: sh test/rocky/test.sh installers/rocky_setup.sh

--- a/installers/packages/jellyfin/rocky_install.sh
+++ b/installers/packages/jellyfin/rocky_install.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]
+then 
+    echo "Please run as root"
+    exit 1
+fi
+
+DISTRO=centos
+VERSION=10.7.7-1
+
+# Install RPM Fusion repositories
+dnf -y install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm \
+    https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
+
+# Install config-manager
+dnf -y install 'dnf-command(config-manager)'
+
+# Enable powertools
+dnf -y config-manager --enable powertools
+
+# Install Dependencies
+dnf -y install SDL2 ffmpeg ffmpeg-devel which
+
+# Install packages
+dnf -y install --nobest https://repo.jellyfin.org/releases/server/${DISTRO}/stable/server/jellyfin-${VERSION}.el7.x86_64.rpm \
+    https://repo.jellyfin.org/releases/server/${DISTRO}/stable/server/jellyfin-server-${VERSION}.el7.x86_64.rpm \
+    https://repo.jellyfin.org/releases/server/${DISTRO}/stable/web/jellyfin-web-${VERSION}.el7.noarch.rpm
+
+# Enable Jellyfin
+systemctl enable jellyfin
+
+# Installation Check
+jellyfin_path=$(which jellyfin)
+if [ -z "${jellyfin_path}" ]
+then
+    echo "Jellyfin was not installed correctly."
+    exit 203
+fi

--- a/installers/packages/zfs/rocky_install.sh
+++ b/installers/packages/zfs/rocky_install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]
+then 
+    echo "Please run as root"
+    exit 1
+fi
+
+# Install ZFS repository
+dnf -y install https://zfsonlinux.org/epel/zfs-release.el8_4.noarch.rpm
+
+# Install packages
+dnf -y install kernel-devel zfs
+
+# Create ZFS module load config
+sh -c "echo zfs > /etc/modules-load.d/zfs.conf"
+
+# Installation Check
+zpool_path=$(which zpool)
+if [ -z "${zpool_path}" ]
+then
+    echo "ZFS was not installed correctly."
+    exit 203
+fi

--- a/installers/rocky_setup.sh
+++ b/installers/rocky_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]
+then 
+    echo "Please run as root"
+    exit 1
+fi
+
+# Update packages
+dnf -y update --refresh
+
+# Install EPEL repository
+dnf -y install epel-release

--- a/installers/server_install_packages.sh
+++ b/installers/server_install_packages.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]
+then 
+    echo "Please run as root"
+    exit 1
+fi
+
+# Variables
+base_dir=$(dirname $0)
+
+# Run Rocky Linux setup script
+sh $base_dir/rocky_setup.sh
+
+# Install packages
+dnf -y install htop neofetch tmux zsh podman @virt virt-top libguestfs-tools virt-install nginx php php-pgsql postgresql-server \
+    samba
+
+# Install ZFS
+sh $base_dir/packages/zfs/rocky_install.sh
+status=$?
+if [ $status -ne 0 ]
+then
+    echo "ZFS failed to install."
+    exit $status
+fi
+
+# Install Jellyfin
+sh $base_dir/packages/jellyfin/rocky_install.sh
+status=$?
+if [ $status -ne 0 ]
+then
+    echo "Jellyfin failed to install."
+    exit $status
+fi
+
+# Enable libvirtd
+systemctl enable libvirtd
+
+# Test neofetch
+neofetch
+
+# Test htop
+htop --version
+
+# Test tmux
+tmux -V
+
+# Test zsh
+zsh --version
+
+# Test podman
+podman --version
+
+# Test qemu
+qemu-img --version
+
+# Test pg
+psql --version
+
+# Test Jellyfin
+jellyfin --version
+
+exit 0

--- a/test/rocky/Dockerfile
+++ b/test/rocky/Dockerfile
@@ -1,0 +1,16 @@
+FROM rockylinux:latest
+
+ARG target
+ARG script
+
+USER root
+
+COPY ${target} /target
+
+WORKDIR /target
+
+RUN sh ${script}
+
+WORKDIR /
+
+RUN rm -rf /target

--- a/test/rocky/test.sh
+++ b/test/rocky/test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+if [ -z "${1}" ]
+then
+    echo "Please specify script to test."
+    exit 1
+fi
+
+SCRIPT=$(readlink -f $1)
+TARGET_DIR=$(dirname $SCRIPT)
+BUILD_PATH=$(dirname $(readlink -f $0))
+IMG=$USER/$(basename $BUILD_PATH)
+TAG="testing"
+
+# Copy target script to pwd
+cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+
+# Test build image with target script
+docker build --no-cache --force-rm -t $IMG:$TAG \
+--build-arg target=$(basename $TARGET_DIR) \
+--build-arg script=$(basename $SCRIPT) \
+$BUILD_PATH
+
+# Set build status code
+STATUS=$?
+
+# Remove testing image
+docker rmi $IMG:$TAG
+
+# Remove target script from pwd
+rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+
+# Exit with build status code
+exit $STATUS


### PR DESCRIPTION
Signed-off-by: Michael Valdron <michael.valdron@gmail.com>

# Changes
- Added `installers/rocky_setup.sh` - Setup script of general stuff to setup in Rocky Linux
- Added `installers/server_install_packages.sh` - Installer of packages for personal server
- Added `test/rocky` - `Dockerfile` and `test.sh` for testing out specified scripts using Rocky Linux
- Changed `.github/workflows/test-setups.yml` - Job added for testing Rocky Linux setup script
- Changed `.github/workflows/test-installers.yml` - Added job for testing server install script
