### PR TITLE
Remove Jellyfin from server base install script

### DIFF
--- a/installers/server_install_packages.sh
+++ b/installers/server_install_packages.sh
@@ -25,15 +25,6 @@ then
     exit $status
 fi
 
-# Install Jellyfin
-sh $base_dir/packages/jellyfin/rocky_install.sh
-status=$?
-if [ $status -ne 0 ]
-then
-    echo "Jellyfin failed to install."
-    exit $status
-fi
-
 # Enable libvirtd
 systemctl enable libvirtd
 
@@ -57,8 +48,5 @@ qemu-img --version
 
 # Test pg
 psql --version
-
-# Test Jellyfin
-jellyfin --version
 
 exit 0


### PR DESCRIPTION
Signed-off-by: Michael Valdron <michael.valdron@gmail.com>

# Description

This change removes the Jellyfin install from the base server installation script in favor of running as container.