### PR TITLE
Replace rockylinux latest tag

### DIFF
--- a/test/rocky/Dockerfile
+++ b/test/rocky/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:latest
+FROM rockylinux:8.6
 
 ARG target
 ARG script


### PR DESCRIPTION
Signed-off-by: Michael Valdron <michael.valdron@gmail.com>

# Description

The `rockylinux` image tag `latest` replaced with `8.6` for Rocky Linux 8.6 image.