### PR TITLE
Script args handling in testing

### DIFF
--- a/test/archlinux/Containerfile
+++ b/test/archlinux/Containerfile
@@ -2,6 +2,7 @@ FROM archlinux:base
 
 ARG target
 ARG script
+ARG args=
 
 ENV SCRIPT_TESTING=1
 
@@ -11,7 +12,7 @@ COPY ${target} /target
 
 WORKDIR /target
 
-RUN sh ${script}
+RUN sh ${script} "${args}"
 
 WORKDIR /
 

--- a/test/archlinux/test.sh
+++ b/test/archlinux/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/debian/bookworm/test.sh
+++ b/test/debian/bookworm/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/debian/bullseye/Containerfile
+++ b/test/debian/bullseye/Containerfile
@@ -2,6 +2,7 @@ FROM debian:11-slim
 
 ARG target
 ARG script
+ARG args=
 
 ENV SCRIPT_TESTING=1
 
@@ -11,7 +12,7 @@ COPY ${target} /target
 
 WORKDIR /target
 
-RUN sh ${script}
+RUN sh ${script} "${args}"
 
 WORKDIR /
 

--- a/test/debian/bullseye/test.sh
+++ b/test/debian/bullseye/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/debian/buster/Containerfile
+++ b/test/debian/buster/Containerfile
@@ -2,6 +2,7 @@ FROM debian:10-slim
 
 ARG target
 ARG script
+ARG args=
 
 ENV SCRIPT_TESTING=1
 
@@ -11,7 +12,7 @@ COPY ${target} /target
 
 WORKDIR /target
 
-RUN sh ${script}
+RUN sh ${script} "${args}"
 
 WORKDIR /
 

--- a/test/debian/buster/test.sh
+++ b/test/debian/buster/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/fedora/Containerfile
+++ b/test/fedora/Containerfile
@@ -2,6 +2,7 @@ FROM fedora:latest
 
 ARG target
 ARG script
+ARG args=
 
 ENV SCRIPT_TESTING=1
 
@@ -11,7 +12,7 @@ COPY ${target} /target
 
 WORKDIR /target
 
-RUN sh ${script}
+RUN sh ${script} "${args}"
 
 WORKDIR /
 

--- a/test/fedora/test.sh
+++ b/test/fedora/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/rocky/el8/Containerfile
+++ b/test/rocky/el8/Containerfile
@@ -2,6 +2,7 @@ FROM rockylinux:8.6
 
 ARG target
 ARG script
+ARG args=
 
 ENV SCRIPT_TESTING=1
 
@@ -11,7 +12,7 @@ COPY ${target} /target
 
 WORKDIR /target
 
-RUN sh ${script}
+RUN sh ${script} "${args}"
 
 WORKDIR /
 

--- a/test/rocky/el8/test.sh
+++ b/test/rocky/el8/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status

--- a/test/rocky/el9/test.sh
+++ b/test/rocky/el9/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+args=($@)
+
 if [ -z "${1}" ]
 then
     echo "Please specify script to test."
@@ -7,29 +9,32 @@ then
 fi
 
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
-SCRIPT=$(readlink -f $1)
-TARGET_DIR=$(dirname $SCRIPT)
-BUILD_PATH=$(dirname $(readlink -f $0))
-IMG=$USER/$(basename $BUILD_PATH)
-TAG="testing"
+script=$(readlink -f $1)
+target_dir=$(dirname $script)
+build_path=$(dirname $(readlink -f $0))
+img=$USER/$(basename $build_path)
+tag="testing"
+
+unset 'args[0]'
 
 # Copy target script to pwd
-cp -r $TARGET_DIR $BUILD_PATH/$(basename $TARGET_DIR)
+cp -r $target_dir $build_path/$(basename $target_dir)
 
 # Test build image with target script
-${CONTAINER_ENGINE} build --no-cache --force-rm -t $IMG:$TAG \
---build-arg target=$(basename $TARGET_DIR) \
---build-arg script=$(basename $SCRIPT) \
-$BUILD_PATH
+${CONTAINER_ENGINE} build --no-cache --force-rm -t $img:$tag \
+--build-arg target=$(basename $target_dir) \
+--build-arg script=$(basename $script) \
+--build-arg args="${args[@]}" \
+$build_path
 
 # Set build status code
-STATUS=$?
+status=$?
 
 # Remove testing image
-${CONTAINER_ENGINE} rmi $IMG:$TAG
+${CONTAINER_ENGINE} rmi $img:$tag
 
 # Remove target script from pwd
-rm -rf $BUILD_PATH/$(basename $TARGET_DIR)
+rm -rf $build_path/$(basename $target_dir)
 
 # Exit with build status code
-exit $STATUS
+exit $status


### PR DESCRIPTION
Signed-off-by: Michael Valdron <michael.valdron@gmail.com>

# Description

Adds the ability to pass arguments to the script being tested on.

**Example**
```sh
sh test/fedora/test.sh installers/fedora_setup.sh 1 # <-- has '1' passed to fedora_setup.sh
```